### PR TITLE
Add endpoint to produce checkin/item reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ The following should be installed in your machine:
 
 -----
 
+## How To Contribute
+
+### Issues
+
+Issues are always very welcome. Please be sure to follow the [issue template](https://github.com/andela/engineering-playbook/issues/new).
+
+### Pull requests
+
+I am glad to get pull request if anything is missing or something is buggy. However, there are a couple of things you can do to make life easier for the maintainer:
+
+- Explain the issue that your PR is solving - or link to an existing issue
+
+
+-----
+
 ## End points
 
 ### Postman Collection
@@ -168,7 +183,7 @@ NB: Deleting a store will delete all items and checkouts related to it
 
 ### Generate Cehckout Report:
 
-`GET /reports`
+`GET /reports/checkout`
 
 always add a `startDate` and `endDate` as url query e.g. `GET /reports?startDate=2019-10-15T00:05:32.000Z&endDate=2019-11-07T00:05:32.000Z` to return a report of checkouts during that period.
 
@@ -178,16 +193,14 @@ Returns a checkout report
 
 NB: On top of startDate and endDate, you could add other queries e.g. `artNumber=s001&store=ntinda&color=black` to return only black items of artNumber s001 in the ntinda store.
 
------
+### Generate Cehckin Report:
 
-## How To Contribute
+`GET /reports/checkin`
 
-### Issues
+always add a `startDate` and `endDate` as url query e.g. `GET /reports?startDate=2019-10-15T00:05:32.000Z&endDate=2019-11-07T00:05:32.000Z` to return a report of checkouts during that period.
 
-Issues are always very welcome. Please be sure to follow the [issue template](https://github.com/andela/engineering-playbook/issues/new).
+dates should be of `iso 8601` format
 
-### Pull requests
+Returns a checkin report
 
-I am glad to get pull request if anything is missing or something is buggy. However, there are a couple of things you can do to make life easier for the maintainer:
-
-- Explain the issue that your PR is solving - or link to an existing issue
+NB: On top of startDate and endDate, you could add other queries e.g. `artNumber=s001&store=ntinda&color=black` to return only black items of artNumber s001 in the ntinda store.

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -80,6 +80,69 @@ class ReportsController {
     }
   }
 
+  static async getCheckinReport(req, res, next) {
+    try {
+      const { artNumber, description, color, store, startDate, endDate } = req.query;
+      if ((startDate && !moment(startDate).isValid()) || (endDate && !moment(endDate).isValid())) {
+        return Errors.errorHandler(res, 404, 'Invalid date format provided please provide date in iso 8601 string');
+      }
+      let artNumberFilter = { [Op.ne]: null }
+      let descriptionFilter = { [Op.ne]: null }
+      let colorFilter = { [Op.ne]: null }
+      let storeFilter = { [Op.ne]: null }
+      let startDateFilter = { [Op.ne]: null }
+      let endDateFilter = { [Op.ne]: null }
+      if (artNumber) {
+        artNumberFilter = { [Op.eq]: artNumber }
+      }
+      if (description) {
+        descriptionFilter = { [Op.substring]: description }
+      }
+      if (color) {
+        colorFilter = { [Op.eq]: color }
+      }
+      if (store) {
+        storeFilter = { [Op.eq]: store }
+      }
+      if (startDate) {
+        startDateFilter = startDate
+      }
+      if (endDate) {
+        endDateFilter = endDate
+      }
+      const retrievedReport = await models.item.findAll({
+        where: {
+          createdAt: {
+            [Op.lte]: endDateFilter,
+            [Op.gte]: startDateFilter,
+          },
+          artNumber: artNumberFilter,
+          description: descriptionFilter,
+          color: colorFilter,
+        },
+        attributes: ['id', 'artNumber', 'color', 'description', 'quantity', 'createdAt', 'updatedAt'],
+        include: [{
+          model: models.stores,
+          as: 'stores',
+          where: {
+            store: storeFilter
+          },
+          attributes: ['id', 'store']
+        }]
+      });
+
+      const formattedReport = retrievedReport.map(ReportsController.rearrangeCheckinReport)
+
+      return res.status(200).json({
+        success: true,
+        message: 'Report retrieved successfully',
+        checkinReport: formattedReport,
+      })
+    } catch (error) {
+      next(error);
+    }
+  }
+
   static rearrangeReport (reportObject) {
     const formattedReport = {
       id: reportObject.id,
@@ -94,6 +157,21 @@ class ReportsController {
       itemQuantity: reportObject.items.quantity,
       storeId: reportObject.items.stores.id,
       store: reportObject.items.stores.store,
+    };
+    return formattedReport;
+  }
+
+  static rearrangeCheckinReport (reportObject) {
+    const formattedReport = {
+      id: reportObject.id,
+      artNumber: reportObject.artNumber,
+      color: reportObject.color,
+      description: reportObject.description,
+      checkoutQuantity: reportObject.quantity,
+      createdAt: reportObject.createdAt,
+      updatedAt: reportObject.updatedAt,
+      storeId: reportObject.stores.id,
+      store: reportObject.stores.store,
     };
     return formattedReport;
   }

--- a/src/routes/reportsroute.js
+++ b/src/routes/reportsroute.js
@@ -3,6 +3,7 @@ import ReportsController from '../controllers/reportsController';
 
 const router = express.Router();
 
-router.get('/reports', ReportsController.getReport);
+router.get('/reports/checkout', ReportsController.getReport);
+router.get('/reports/checkin', ReportsController.getCheckinReport);
 
 export default router;


### PR DESCRIPTION
## What does this PR do
This PR adds an endpoint to return checkin/item reports

### Tasks to be completed
- add checkin report endpoint
- rename checkout report endpoint
- update README

### Things to be noted
- The Checkout endpoint now runs on `/reports/checkout` and checking reports on `/reports/checkin`
